### PR TITLE
Store locale in cookie when it changes

### DIFF
--- a/app/cookie.js
+++ b/app/cookie.js
@@ -1,0 +1,6 @@
+import { createCookie } from "remix";
+
+export let i18nCookie = createCookie("i18n", {
+  sameSite: "lax",
+  path: "/",
+});

--- a/app/i18n.server.js
+++ b/app/i18n.server.js
@@ -1,10 +1,12 @@
-import { RemixI18Next } from 'remix-i18next'
-import Backend from 'i18next-fs-backend'
-import { resolve } from 'node:path'
-import i18nextOptions from './i18nextOptions'
+import { RemixI18Next } from "remix-i18next";
+import Backend from "i18next-fs-backend";
+import { resolve } from "node:path";
+import i18nextOptions from "./i18nextOptions";
+import { i18nCookie } from "./cookie";
 
 export default new RemixI18Next({
   detection: {
+    cookie: i18nCookie,
     // This is the list of languages your application supports
     supportedLanguages: i18nextOptions.supportedLngs,
     // This is the language you want to use in case the user language is not
@@ -14,10 +16,10 @@ export default new RemixI18Next({
   // This is the configuration for i18next used when translating messages server
   // side only
   i18next: {
-    backend: { loadPath: resolve('./public/locales/{{lng}}/{{ns}}.json') },
+    backend: { loadPath: resolve("./public/locales/{{lng}}/{{ns}}.json") },
   },
   // The backend you want to use to load the translations
   // Tip: You could pass `resources` to the `i18next` configuration and avoid
   // a backend here
   backend: Backend,
-})
+});

--- a/app/root.jsx
+++ b/app/root.jsx
@@ -12,12 +12,15 @@ import { useChangeLanguage } from 'remix-i18next'
 import remixI18n from './i18n.server'
 import { useTranslation } from 'react-i18next'
 import styles from './styles/index.css'
+import { i18nCookie } from './cookie'
 
 export const loader = async ({ request }) => {
   const locale = await remixI18n.getLocale(request)
   const t = await remixI18n.getFixedT(request, 'common')
   const title = t('headTitle')
-  return json({ locale, title })
+  return json({ locale, title }, {
+    headers: {"Set-Cookie": await i18nCookie.serialize(locale)}
+  })
 }
 
 export const handle = {


### PR DESCRIPTION
This PR shows how to store the locale in a cookie so after the user change it with the links it will keep the user preference.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included
- [ ] documentation is changed or added